### PR TITLE
Added the ability to specify a firefox profile path to be used when starting firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ For full usage details run the following command:
       --chromeopts=str     json string of google chrome options to set (webdriver).
       --firefoxpath=path   path to the target firefox binary.
       --firefoxpref=str    json string of firefox preferences to set (webdriver).
+      --profilepath=path  path to the firefox profile directory (webdriver).
       --operapath=path     path to the opera driver.
       --browser=str        target browser (standalone rc server).
       --environment=str    target environment (grid rc).
@@ -158,6 +159,15 @@ If you're using WebDriver and Firefox it's possible to set custom preferences. T
 ### Example (disable addon compatibility checking)
 
     --firefoxpref='{"extensions.checkCompatibility.nightly":false}'
+
+Specifying a Firefox profile
+----------------------------
+
+If you're using WebDriver and Firefox it's possible to specify an existing Firefox profile to use when starting Firefox.
+
+### Example (use the profile located at /path/to/profile_directory)
+
+    --profilepath='/path/to/profile_directory'
 
 Setting Google Chrome options
 -----------------------------

--- a/pytest_mozwebqa/pytest_mozwebqa.py
+++ b/pytest_mozwebqa/pytest_mozwebqa.py
@@ -200,6 +200,11 @@ def pytest_addoption(parser):
                      dest='firefox_preferences',
                      metavar='str',
                      help='json string of firefox preferences to set (webdriver).')
+    group._addoption('--profilepath',
+                     action='store',
+                     dest='profile_path',
+                     metavar='str',
+                     help='path to the firefox profile to use (webdriver).')
     group._addoption('--chromeopts',
                      action='store',
                      dest='chrome_options',

--- a/pytest_mozwebqa/selenium_client.py
+++ b/pytest_mozwebqa/selenium_client.py
@@ -31,6 +31,7 @@ class Client(object):
             self.chrome_options = options.chrome_options
             self.firefox_path = options.firefox_path
             self.firefox_preferences = options.firefox_preferences
+            self.profile_path = options.profile_path
             self.opera_path = options.opera_path
             self.timeout = options.webqatimeout
 
@@ -89,7 +90,7 @@ class Client(object):
             else:
                 capabilities = getattr(webdriver.DesiredCapabilities, self.browser_name.upper())
             if self.browser_name.upper() == 'FIREFOX':
-                profile = self.create_firefox_profile(self.firefox_preferences)
+                profile = self.create_firefox_profile(self.firefox_preferences, self.profile_path)
             else:
                 profile = None
             if self.browser_version:
@@ -123,7 +124,7 @@ class Client(object):
 
         elif self.driver.upper() == 'FIREFOX':
             binary = self.firefox_path and FirefoxBinary(self.firefox_path) or None
-            profile = self.create_firefox_profile(self.firefox_preferences)
+            profile = self.create_firefox_profile(self.firefox_preferences, self.profile_path)
             self.selenium = webdriver.Firefox(
                 firefox_binary=binary,
                 firefox_profile=profile)
@@ -149,8 +150,8 @@ class Client(object):
         else:
             return self.selenium.get_eval('selenium.sessionId')
 
-    def create_firefox_profile(self, preferences):
-        profile = webdriver.FirefoxProfile()
+    def create_firefox_profile(self, preferences, profile_path):
+        profile = webdriver.FirefoxProfile(profile_path)
         if preferences:
             [profile.set_preference(k, v) for k, v in json.loads(preferences).items()]
         profile.assume_untrusted_cert_issuer = self.assume_untrusted

--- a/testing/test_webdriver_client.py
+++ b/testing/test_webdriver_client.py
@@ -25,3 +25,74 @@ def testStartWebDriverClient(testdir):
                                 file_test)
     passed, skipped, failed = reprec.listoutcomes()
     assert len(passed) == 1
+
+def testSpecifyingFirefoxProfile(testdir):
+    """Test that a specified profile is used when starting firefox.
+        The profile changes the colors in the browser, which are then reflected when calling
+        value_of_css_property.
+    """
+    path_to_profile_folder = _createProfileFolder()
+    file_test = testdir.makepyfile("""
+        import pytest, time
+        @pytest.mark.nondestructive
+        def test_selenium(mozwebqa):
+            mozwebqa.selenium.get('http://localhost:8000/')
+            header = mozwebqa.selenium.find_element_by_tag_name('h1')
+            anchor = mozwebqa.selenium.find_element_by_tag_name('a')
+            header_color = header.value_of_css_property('color')
+            anchor_color = anchor.value_of_css_property('color')
+            assert header_color == 'rgba(255,0,0,1)'
+            assert anchor_color == 'rgba(255,105,180,1)'
+    """)
+    reprec = testdir.inline_run('--baseurl=http://localhost:8000',
+        '--api=webdriver',
+        '--driver=firefox',
+        '--profilepath=' + path_to_profile_folder,
+        file_test)
+    passed, skipped, failed = reprec.listoutcomes()
+    assert len(passed) == 1
+
+def testSpecifyingFirefoxProfileAndOverridingPreferences(testdir):
+    """Test that a specified profile is used when starting firefox.
+        The profile changes the colors in the browser, which are then reflected when calling
+        value_of_css_property. The test checks that the color of the h1 tag is overridden by
+        the profile, while the color of the a tag is overridden by the preference.
+    """
+    path_to_profile_folder = _createProfileFolder()
+    file_test = testdir.makepyfile("""
+        import pytest, time
+        @pytest.mark.nondestructive
+        def test_selenium(mozwebqa):
+            mozwebqa.selenium.get('http://localhost:8000/')
+            header = mozwebqa.selenium.find_element_by_tag_name('h1')
+            anchor = mozwebqa.selenium.find_element_by_tag_name('a')
+            header_color = header.value_of_css_property('color')
+            anchor_color = anchor.value_of_css_property('color')
+            assert header_color == 'rgba(255,0,0,1)'
+            assert anchor_color == 'rgba(255,0,0,1)'
+    """)
+    reprec = testdir.inline_run('--baseurl=http://localhost:8000',
+        '--api=webdriver',
+        '--driver=firefox',
+        '--firefoxpref=''{"browser.anchor_color":"#FF0000"}''',
+        '--profilepath=' + path_to_profile_folder,
+        file_test)
+    passed, skipped, failed = reprec.listoutcomes()
+    assert len(passed) == 1
+
+def _createProfileFolder():
+    import os
+    path_to_profile_folder = os.path.join(os.path.split(os.path.dirname(__file__))[0], 'firefox_profile')
+    if not os.path.exists(path_to_profile_folder):
+        os.makedirs(path_to_profile_folder)
+    prefs = [
+        'user_pref("browser.anchor_color", "#FF69B4");',
+        'user_pref("browser.display.background_color", "#FFFF66");',
+        'user_pref("browser.display.foreground_color", "#FF0000");',
+        'user_pref("browser.display.use_document_colors", false);',
+        'user_pref("browser.visited_color", "#FF99FF");'
+    ]
+    with open(os.path.join(path_to_profile_folder, 'prefs.js'), 'w') as prefs_js:
+        prefs_js.writelines(prefs)
+    return path_to_profile_folder
+

--- a/testing/webserver.py
+++ b/testing/webserver.py
@@ -32,10 +32,11 @@ class HtmlOnlyHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         """GET method handler."""
+
         self.send_response(200)
         self.send_header('Content-type', 'text/html')
         self.end_headers()
-        self.wfile.write('<html><body><h1>Success!</h1></body></html>')
+        self.wfile.write('<html><body><h1>Success!</h1><a href="#">Anchor text</a></body></html>')
 
     def log_message(self, format, *args):
         """Override default to avoid trashing stderr"""


### PR DESCRIPTION
I think this still preserves the ability to customize firefox options via --firefoxpref, but I haven't tested that. This pull request includes a test that I wrote to manually verify that the specified profile was being used. That test expects a firefox profile to be in projectdir/profiles/Test1. I didn't include my test profile in there as it's large with many files. I don't think that test has any place in an automated test suite, but I left it in there in case you want to run it to see for yourself. Ideally we'd come up with a way of testing whether the specified profile was actually loaded.
