### PR TITLE
Update Sauce Labs privacy settings/marks and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,15 @@ be project specific.
     baseurl: 'http://www.example.com'
     api: 'rc'
     tags: 'tag1, tag2'
+    privacy: 'public restricted'
 
 The `tags` entry is an optional comma separated list of tags that are set when
 using Sauce Labs. This is useful for filtering the list of jobs based on the
 application under test or similar.
+
+The `privacy` setting is used when you run the tests on Sauce Labs - its used
+to set the visibility of tests (this corresponds to the `public` capability entry
+used by Sauce Labs).
 
 ### Examples
 
@@ -227,6 +232,12 @@ Privacy
 -------
 
 With Selenium RC you can capture log files. By default log files are not captured as these may contain confidential data such as user credentials. If you are confident that a test does not contain such data, you can explicitly set the test as public (the public mark has no effect on WebDriver tests, which do not capture logs):
+
+Privacy marks have higher priority than the `privacy` entry in `mozwebqa.cfg`.
+
+### List of applicable privacy marks:
+
+    private, team, share, public_restricted, public
 
 ### Example
 

--- a/pytest_mozwebqa/sauce_labs.py
+++ b/pytest_mozwebqa/sauce_labs.py
@@ -46,17 +46,25 @@ class Client(selenium_client.Client):
             raise pytest.UsageError("--platform must be specified when using the 'rc' api with sauce labs.")
 
     @property
+    def privacy(self):
+        privacy_marks = ['private', 'team', 'share', 'public_restricted', 'public']
+        for privacy_mark in privacy_marks:
+            if privacy_mark in self.keywords:
+                return privacy_mark.replace("_", " ")
+        return None
+
+    @property
     def common_settings(self):
-        config = ConfigParser.ConfigParser(defaults={'tags': ''})
+        config = ConfigParser.ConfigParser(defaults={'tags': '', 'privacy': 'private'})
         config.read('mozwebqa.cfg')
         tags = config.get('DEFAULT', 'tags').split(',')
         from _pytest.mark import MarkInfo
         tags.extend([mark for mark in self.keywords.keys() if isinstance(self.keywords[mark], MarkInfo)])
+        privacy = self.privacy or config.get('DEFAULT', 'privacy')
         return {'build': self.build or None,
                 'name': self.test_id,
                 'tags': tags,
-                'public': 'private' not in self.keywords,
-                'restricted-public-info': 'public' not in self.keywords}
+                'public': privacy}
 
     def start_webdriver_client(self):
         capabilities = self.common_settings


### PR DESCRIPTION
Update for privacy settings used on Sauce Labs.
This adds the option to set the default privacy mode for tests in `mozwebqa.cfg` and updates the marks that can be set for each test separately using `@pytest.mark.[privacy_mode]` - this **overrides** the default `privacy` entry in `mozwebqa.cfg`. 
