### PR TITLE
Add simple headless testing support with PhantomJS

### DIFF
--- a/pytest_mozwebqa/selenium_client.py
+++ b/pytest_mozwebqa/selenium_client.py
@@ -162,6 +162,8 @@ class Client(object):
                 capabilities=capabilities or None)
         elif self.driver.upper() == 'IE':
             self.selenium = webdriver.Ie()
+        elif self.driver.upper() == 'PHANTOMJS':
+            self.selenium = webdriver.PhantomJS()
         elif self.driver.upper() == 'OPERA':
             capabilities.update(webdriver.DesiredCapabilities.OPERA)
             self.selenium = webdriver.Opera(executable_path=self.opera_path,


### PR DESCRIPTION
added phantomjs option in start_webdriver_client to allow simple headless support
