### PR TITLE
Output request headers when initial test for baseurl fails. Fixes #130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+1.3
+-----
+* Output request headers when initial test for baseurl fails. Fixes #130
+
 1.2
 -----
 * Improved handling of Firefox preferences and additional capabilities. Fixes #103 & #104

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pytest-mozwebqa',
-      version='1.2',
+      version='1.3',
       description='Mozilla WebQA plugin for py.test.',
       author='Dave Hunt',
       author_email='dhunt@mozilla.com',

--- a/testing/test_startup.py
+++ b/testing/test_startup.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+pytestmark = pytestmark = [pytest.mark.skip_selenium,
+                           pytest.mark.nondestructive]
+
+
+def testBadBaseUrlGeneratesExpectedMessage(testdir, webserver):
+    STATUS_CODE = 500
+
+    testdir.makepyfile(test_one="""
+        import pytest
+        @pytest.mark.skip_selenium
+        @pytest.mark.nondestructive
+        def test_selenium(mozwebqa):
+            assert True
+    """)
+    result = testdir.runpytest('--baseurl=http://localhost:%s/%s/' % (
+        webserver.port, STATUS_CODE))
+    assert result.ret != 0
+    # tracestyle is native by default for hook failures
+    result.stdout.fnmatch_lines([
+        "*INTERNALERROR*AssertionError*Base URL did not return status code "
+        "200 or 401*Response: %s, Headers:*{*}*" % STATUS_CODE
+    ])

--- a/testing/webserver.py
+++ b/testing/webserver.py
@@ -34,7 +34,9 @@ class HtmlOnlyHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         """GET method handler."""
 
-        self.send_response(200)
+        path_parts = self.path.split('/')
+        response_code = len(path_parts) == 3 and int(path_parts[1]) or 200
+        self.send_response(response_code)
         self.send_header('Content-type', 'text/html; charset="utf-8"')
         self.end_headers()
         self.wfile.write(


### PR DESCRIPTION
Add timeout to requests.get() calls
Fix pep8 issues
