### PR TITLE
Allow Selenium host and port to be set using environment variables

### DIFF
--- a/pytest_mozwebqa/pytest_mozwebqa.py
+++ b/pytest_mozwebqa/pytest_mozwebqa.py
@@ -220,13 +220,13 @@ def pytest_addoption(parser):
                      help='target platform version (webdriver).')
     group._addoption('--host',
                      action='store',
-                     default='localhost',
+                     default=os.environ.get('SELENIUM_HOST', 'localhost'),
                      metavar='str',
                      help='host that selenium server is listening on. (default: %default)')
     group._addoption('--port',
                      action='store',
                      type='int',
-                     default=4444,
+                     default=os.environ.get('SELENIUM_PORT', 4444),
                      metavar='num',
                      help='port that selenium server is listening on. (default: %default)')
     group._addoption('--driver',


### PR DESCRIPTION
This will allow us to use an alternate Selenium server/hub by changing environment variables. It would be good to do this ahead of setting up our new Selenium Grid instance so that we can change this in one place within Jenkins.